### PR TITLE
fix: stop excluding .pdf files from Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,10 +2,8 @@ exclude:
   - "**/*.qmd"
   - "**/*.Rmd"
   - "**/*.R"
-  - "**/*.pdf"
   - "**/*.log"
   - "**/*.Rproj"
-
   - "**/*.rds"
   - "**/*.parquet"
   - "**/*.qs"
@@ -27,7 +25,6 @@ exclude:
   - "AGENTS.md"
   - "CLAUDE.md"
   - "GEMINI.md"
-
 jekyll-optional-front-matter:
   enabled: false
 plugins:


### PR DESCRIPTION
Allows the generated PDF presentations to be deployed to GitHub Pages alongside the HTML versions.