### PR TITLE
Add commit-msg hook to strip Claude-Session trailers

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Commit-msg hook: clean up Claude Code injections from commit messages
+
+COMMIT_MSG_FILE="$1"
+
+# Strip Claude-Session: trailer lines silently
+sed -i '/^Claude-Session:/d' "$COMMIT_MSG_FILE"
+
+# Block Co-Authored-By: Claude lines (case-insensitive)
+if grep -qi "Co-Authored-By:.*Claude" "$COMMIT_MSG_FILE"; then
+  echo ""
+  echo "ERROR: Commit message contains 'Co-Authored-By: Claude' line!"
+  echo ""
+  echo "This keeps commit messages clean and reflects actual authorship."
+  echo ""
+  echo "To fix: Remove the Co-Authored-By line from your commit message and try again."
+  echo ""
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Adds hooks/commit-msg, wired via the existing core.hooksPath = hooks config
- Silently strips `Claude-Session:` trailer lines from commit messages
- Blocks commits containing `Co-Authored-By: Claude` (case-insensitive)
- Matches the pattern already used in describe_data/poc_planning_tool

Closes #138