### PR TITLE
Render email as mailto link on final slide

### DIFF
--- a/talk_rr_reinsrecover_202607/talk_rr_reinsrecover_202607.html
+++ b/talk_rr_reinsrecover_202607/talk_rr_reinsrecover_202607.html
@@ -1522,7 +1522,7 @@ Treaty: \text{Losses} \rightarrow \text{Recoveries}
 <h1>Questions</h1>
 <p><br>
 </p>
-<p>mickcooney@gmail.com</p>
+<p><a href="mailto:mickcooney@gmail.com" class="email">mickcooney@gmail.com</a></p>
 <p><br>
 </p>
 <p><a href>https://github.com/kaybenleroll/data_workshops/talk_rr_reinsrecover_202607</a></p>

--- a/talk_rr_reinsrecover_202607/talk_rr_reinsrecover_202607.qmd
+++ b/talk_rr_reinsrecover_202607/talk_rr_reinsrecover_202607.qmd
@@ -364,7 +364,7 @@ Regulatory authority
 \
 
 
-mickcooney@gmail.com
+[mickcooney@gmail.com](mailto:mickcooney@gmail.com)
 
 \
 


### PR DESCRIPTION
## Summary
- Wrap the email address on the Questions/final slide in a markdown mailto link, matching the title-slide author rendering.
- Patch the already-rendered html output to match (PDF text is unaffected visually).

## Test plan
- [x] Verified rendered html now emits `<a href="mailto:...">`