### PR TITLE
Use markdown autolinks for email and repo URL on final slide

### DIFF
--- a/talk_rr_reinsrecover_202607/talk_rr_reinsrecover_202607.html
+++ b/talk_rr_reinsrecover_202607/talk_rr_reinsrecover_202607.html
@@ -1525,7 +1525,7 @@ Treaty: \text{Losses} \rightarrow \text{Recoveries}
 <p><a href="mailto:mickcooney@gmail.com" class="email">mickcooney@gmail.com</a></p>
 <p><br>
 </p>
-<p><a href>https://github.com/kaybenleroll/data_workshops/talk_rr_reinsrecover_202607</a></p>
+<p><a href="https://github.com/kaybenleroll/data_workshops/talk_rr_reinsrecover_202607" class="uri">https://github.com/kaybenleroll/data_workshops/talk_rr_reinsrecover_202607</a></p>
 
 </section>
     </div>

--- a/talk_rr_reinsrecover_202607/talk_rr_reinsrecover_202607.qmd
+++ b/talk_rr_reinsrecover_202607/talk_rr_reinsrecover_202607.qmd
@@ -364,10 +364,10 @@ Regulatory authority
 \
 
 
-[mickcooney@gmail.com](mailto:mickcooney@gmail.com)
+<mickcooney@gmail.com>
 
 \
 
 
-[https://github.com/kaybenleroll/data_workshops/talk_rr_reinsrecover_202607]()
+<https://github.com/kaybenleroll/data_workshops/talk_rr_reinsrecover_202607>
 


### PR DESCRIPTION
## Summary
- Switch the email link to pandoc's `<email>` autolink shorthand, matching the title-slide style.
- Fix the repo URL, which was a broken `[text]()` link with an empty href, to a proper `<url>` autolink.

## Test plan
- [x] Verified rendered html emits real `href` attributes for both links