### PR TITLE
Use markdown autolinks for bare URLs/emails on talk final slides

### DIFF
--- a/talk_bm_btydbayes_202211/btyd_bayes_talk.qmd
+++ b/talk_bm_btydbayes_202211/btyd_bayes_talk.qmd
@@ -1367,14 +1367,14 @@ Add monetary modelling
 
 This talk...
 
-[https://github.com/kaybenleroll/data_workshops/talk_bm_btydbayes_202211]()
+<https://github.com/kaybenleroll/data_workshops/talk_bm_btydbayes_202211>
 
 \
 
 
 Workshop...
 
-[https://github.com/kaybenleroll/data_workshops/ws_clvbayes_202201]()
+<https://github.com/kaybenleroll/data_workshops/ws_clvbayes_202201>
 
 
 

--- a/talk_bm_survivalbayes_202512/bayesian_survival_talk.qmd
+++ b/talk_bm_survivalbayes_202512/bayesian_survival_talk.qmd
@@ -998,21 +998,21 @@ Needs a lot more work to be usable
 \
 
 
-[https://github.com/kaybenleroll/data_workshops/talk_bm_survivalbayes_202512]()
+<https://github.com/kaybenleroll/data_workshops/talk_bm_survivalbayes_202512>
 
 \
 
 
 Main project
 
-[https://github.com/kaybenleroll/bayesian_survival_analysis]()
+<https://github.com/kaybenleroll/bayesian_survival_analysis>
 
 \
 
 
 Old Workshop (non-Bayes)
 
-[https://kaybenleroll.github.io/data_workshops/oldertalks/ws_survival_201809/worksheet_survival.html]()
+<https://kaybenleroll.github.io/data_workshops/oldertalks/ws_survival_201809/worksheet_survival.html>
 
 :::
 

--- a/talk_cirdas_master_202311/ws_01_intro.qmd
+++ b/talk_cirdas_master_202311/ws_01_intro.qmd
@@ -195,7 +195,7 @@ Thank You
 
 \
 
-mcooney\@describedata.com
+<mcooney@describedata.com>
 
 \
 

--- a/talk_cirdas_master_202311/ws_02_simplicity.qmd
+++ b/talk_cirdas_master_202311/ws_02_simplicity.qmd
@@ -299,7 +299,7 @@ Thank You
 
 \
 
-mcooney@describedata.com
+<mcooney@describedata.com>
 
 \
 

--- a/talk_cirdas_master_202311/ws_03_uncertainty.qmd
+++ b/talk_cirdas_master_202311/ws_03_uncertainty.qmd
@@ -206,7 +206,7 @@ Thank You
 
 \
 
-mcooney@describedata.com
+<mcooney@describedata.com>
 
 \
 

--- a/talk_cirdas_master_202311/ws_04_statistics.qmd
+++ b/talk_cirdas_master_202311/ws_04_statistics.qmd
@@ -470,7 +470,7 @@ Thank You
 
 \
 
-mcooney@describedata.com
+<mcooney@describedata.com>
 
 \
 

--- a/talk_cirdas_master_202311/ws_05_ml.qmd
+++ b/talk_cirdas_master_202311/ws_05_ml.qmd
@@ -671,7 +671,7 @@ Assign "topics" to each "document"
 ![](img/nlp_lda.png)
 
 
-Reference: [http://dontloo.github.io/blog/lda/]()
+Reference: <http://dontloo.github.io/blog/lda/>
 
 
 ## word2vec
@@ -708,7 +708,7 @@ Thank You
 
 \
 
-mcooney@describedata.com
+<mcooney@describedata.com>
 
 \
 

--- a/talk_cirdas_master_202311/ws_06_dataviz.qmd
+++ b/talk_cirdas_master_202311/ws_06_dataviz.qmd
@@ -784,7 +784,7 @@ Thank You
 
 \
 
-mcooney@describedata.com
+<mcooney@describedata.com>
 
 \
 

--- a/talk_cirdas_master_202311/ws_07_started.qmd
+++ b/talk_cirdas_master_202311/ws_07_started.qmd
@@ -164,7 +164,7 @@ Thank You
 
 \
 
-mcooney@describedata.com
+<mcooney@describedata.com>
 
 \
 

--- a/talk_cirdas_master_202311/ws_08_recap.qmd
+++ b/talk_cirdas_master_202311/ws_08_recap.qmd
@@ -275,7 +275,7 @@ Get In Touch!!!
 
 \
 
-mcooney@describedata.com
+<mcooney@describedata.com>
 
 \
 

--- a/talk_citi_pgmfraud_202305/citi_pgm_fraud.qmd
+++ b/talk_citi_pgmfraud_202305/citi_pgm_fraud.qmd
@@ -89,7 +89,7 @@ dag(~Sprinkler:Rain + Wet:Sprinkler + Wet:Rain) |>
 
 This talk...
 
-[https://github.com/kaybenleroll/data_workshops/talk_citi_pgmfraud_202305]()
+<https://github.com/kaybenleroll/data_workshops/talk_citi_pgmfraud_202305>
 
 
 

--- a/talk_dds_btydbayes_202504/btyd_bayes_talk.qmd
+++ b/talk_dds_btydbayes_202504/btyd_bayes_talk.qmd
@@ -1292,14 +1292,14 @@ Add monetary modelling
 
 This talk...
 
-[https://github.com/kaybenleroll/data_workshops/talk_bm_btydbayes_202211]()
+<https://github.com/kaybenleroll/data_workshops/talk_bm_btydbayes_202211>
 
 \
 
 
 Workshop...
 
-[https://github.com/kaybenleroll/data_workshops/ws_clvbayes_202201]()
+<https://github.com/kaybenleroll/data_workshops/ws_clvbayes_202201>
 
 
 

--- a/talk_dds_survivalbayes_202603/bayesian_survival_talk.qmd
+++ b/talk_dds_survivalbayes_202603/bayesian_survival_talk.qmd
@@ -1272,21 +1272,21 @@ Needs a lot more work to be usable
 \
 
 
-[https://github.com/kaybenleroll/data_workshops/talk_bm_survivalbayes_202512]()
+<https://github.com/kaybenleroll/data_workshops/talk_bm_survivalbayes_202512>
 
 \
 
 
 Main project
 
-[https://github.com/kaybenleroll/bayesian_survival_analysis]()
+<https://github.com/kaybenleroll/bayesian_survival_analysis>
 
 \
 
 
 Old Workshop (non-Bayes)
 
-[https://kaybenleroll.github.io/data_workshops/oldertalks/ws_survival_201809/worksheet_survival.html]()
+<https://kaybenleroll.github.io/data_workshops/oldertalks/ws_survival_201809/worksheet_survival.html>
 
 :::
 

--- a/talk_dpff_datastart_202310/talk_dpff_datastart_202310.qmd
+++ b/talk_dpff_datastart_202310/talk_dpff_datastart_202310.qmd
@@ -132,7 +132,7 @@ This talk...
 \
 
 
-[https://github.com/kaybenleroll/data_workshops/talk_dpff_datastart_202310]()
+<https://github.com/kaybenleroll/data_workshops/talk_dpff_datastart_202310>
 
 
 

--- a/talk_gaming_dndadv_202301/dnd_advantage_talk.qmd
+++ b/talk_gaming_dndadv_202301/dnd_advantage_talk.qmd
@@ -919,14 +919,14 @@ Effects non-intuitive
 
 Stand-Up Maths YouTube Channel
 
-[https://www.youtube.com/watch?v=X_DdGRjtwAo]()
+<https://www.youtube.com/watch?v=X_DdGRjtwAo>
 
 \
 
 
 Joseph Newton
 
-[https://www.youtube.com/watch?v=R0gewfLILw0]()
+<https://www.youtube.com/watch?v=R0gewfLILw0>
 
 ---
 
@@ -938,7 +938,7 @@ This talk...
 \
 
 
-[https://github.com/kaybenleroll/data_workshops/talk_gaming_dndadv_202301]()
+<https://github.com/kaybenleroll/data_workshops/talk_gaming_dndadv_202301>
 
 
 

--- a/talk_idsc_survivalbayes_202606/bayesian_survival_talk.qmd
+++ b/talk_idsc_survivalbayes_202606/bayesian_survival_talk.qmd
@@ -871,21 +871,21 @@ Needs a lot more work to be usable
 \
 
 
-[https://github.com/kaybenleroll/data_workshops/talk_idsc_survivalbayes_202606]()
+<https://github.com/kaybenleroll/data_workshops/talk_idsc_survivalbayes_202606>
 
 \
 
 
 Main project
 
-[https://github.com/kaybenleroll/bayesian_survival_analysis]()
+<https://github.com/kaybenleroll/bayesian_survival_analysis>
 
 \
 
 
 Old Workshop (non-Bayes)
 
-[https://kaybenleroll.github.io/data_workshops/oldertalks/ws_survival_201809/worksheet_survival.html]()
+<https://kaybenleroll.github.io/data_workshops/oldertalks/ws_survival_201809/worksheet_survival.html>
 
 :::
 


### PR DESCRIPTION
## Summary
- Extends the autolink convention introduced for `talk_rr_reinsrecover_202607` (dda8b33, 05977d3) to the rest of the talks: where a final-slide link's visible text is identical to its target, use `<url>`/`<email>` autolink syntax instead of `[text](url)`.
- Fixes several empty-target link typos (`[url]()`) discovered along the way, including one mid-deck reference link in `ws_05_ml.qmd`.
- Links whose visible text differs from the target (e.g. "Slides for Talk", "Detailed Work") are left unchanged as `[text](url)`.

## Test plan
- [x] Checked every `.qmd` file in the repo's talk directories
- [x] Diffed each change to confirm only autolink/malformed-link fixes, no other content touched